### PR TITLE
fix: only requires nim >= 2.0.0

### DIFF
--- a/dive.nimble
+++ b/dive.nimble
@@ -10,6 +10,6 @@ bin           = @["dive"]
 
 # Dependencies
 
-requires "nim >= 2.1.1"
+requires "nim >= 2.0.0"
 requires "cligen"
 requires "sweet"


### PR DESCRIPTION
alleviate nim's version requirement